### PR TITLE
Temporarily use onKeyUp event in the ToDoApp example to make it work with Firefox

### DIFF
--- a/scalajs-react-examples/src/main/scala/com/xored/scalajs/react/examples/todomvc/TodoApp.scala
+++ b/scalajs-react-examples/src/main/scala/com/xored/scalajs/react/examples/todomvc/TodoApp.scala
@@ -85,12 +85,15 @@ object TodoApp extends TypedReactSpec with TypedEventListeners {
   def render(self: This) = {
     val activeTodoCount = self.state.todos.count(!_.completed)
 
+    // Use onKeyUp temporarily because onKeyPress does not work on Firefox with current version of react
+    //   See https://github.com/facebook/react/pull/1956
+
     <section id="todoapp">
       <header id="header">
         <h1>todos</h1>
         <input id="new-todo"
                onChange={self.onChange}
-               onKeyPress={self.onKeyPress}
+               onKeyUp={self.onKeyPress}
                value={self.state.text}
                placeholder="What needs to be done?"
                autofocus={true}></input>


### PR DESCRIPTION
Use `onKeyUp` temporarily because `onKeyPress` does not work on Firefox with current version of react
See https://github.com/facebook/react/pull/1956

It actually also fix the example with Chromium because there also seems to be problems with `onKeyPress` & `Enter` & `e.keyCode` in react - when I tested `e.keyCode` was always 0 (there is no such problem with `onKeyUp`) so using `e.key` instead with `org.scalajs.dom.extensions.KeyValue` when it's available might be a good idea.
See https://github.com/scala-js/scala-js-dom/blob/master/src/main/scala/org/scalajs/dom/extensions/KeyValue.scala
~  
~  
~  
~                                              
